### PR TITLE
add cmdb.condition.read method

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ For almost every case there is a remote procedure you may call to read from or m
 |                               | `cmdb.category.delete`                |                               | `delete()`                                                |
 |                               | `cmdb.category.purge`                 |                               | `purge()`                                                 |
 | `cmdb.category_info`          | `cmdb.category_info.read`             | `CMDBCategoryInfo`            | `read()`                                                  |
+| `cmdb.condition`              | `cmdb.condition.read`                 | `CMDBCondition`               | `read()`                                                  |
 | `cmdb.dialog`                 | `cmdb.dialog.create`                  | `CMDBDialog`                  | `create()`                                                |
 |                               | `cmdb.dialog.read`                    |                               | `read()`                                                  |
 |                               | `cmdb.dialog.delete`                  |                               | `delete()`                                                |

--- a/src/CMDBCondition.php
+++ b/src/CMDBCondition.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Copyright (C) 2022 synetics GmbH
+ * Copyright (C) 2016-2022 Benjamin Heisig
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Benjamin Heisig <https://benjamin.heisig.name/>
+ * @copyright Copyright (C) 2022 synetics GmbH
+ * @copyright Copyright (C) 2016-2022 Benjamin Heisig
+ * @license http://www.gnu.org/licenses/agpl-3.0 GNU Affero General Public License (AGPL)
+ * @link https://github.com/i-doit/api-client-php
+ */
+
+declare(strict_types=1);
+
+namespace Idoit\APIClient;
+
+use \Exception;
+
+/**
+ * Requests for API namespace 'cmdb.condition'
+ */
+class CMDBCondition extends Request {
+
+    const ATTRIBUTE_CONDITIONS = 'conditions';
+
+    /**
+     * Get list of objects filtered by conditions
+     *
+     * @param array $conditions array of conditions
+     *
+     * @return array Indexed array of associative arrays
+     *
+     * @throws Exception on error
+     */
+    public function read($conditions): array {
+        return $this->api->request(
+            'cmdb.condition.read',
+            [
+                'conditions' => $conditions
+            ]
+        );
+    }
+
+}

--- a/tests/Idoit/APIClient/BaseTest.php
+++ b/tests/Idoit/APIClient/BaseTest.php
@@ -182,6 +182,14 @@ abstract class BaseTest extends TestCase {
         return $this->cmdbCategory;
     }
 
+    public function useCMDBCondition(): CMDBCondition {
+        if (!isset($this->cmdbCondition)) {
+            $this->cmdbCondition = new CMDBCondition($this->api);
+        }
+
+        return $this->cmdbCondition;
+    }
+
     public function useCMDBDialog(): CMDBDialog {
         if (!isset($this->cmdbDialog)) {
             $this->cmdbDialog = new CMDBDialog($this->api);

--- a/tests/Idoit/APIClient/BaseTest.php
+++ b/tests/Idoit/APIClient/BaseTest.php
@@ -58,6 +58,11 @@ abstract class BaseTest extends TestCase {
     protected $cmdbCategory;
 
     /**
+     * @var CMDBCondition|null
+     */
+    protected $cmdbCondition;
+
+    /**
      * @var CMDBDialog|null
      */
     protected $cmdbDialog;

--- a/tests/Idoit/APIClient/CMDBConditionTest.php
+++ b/tests/Idoit/APIClient/CMDBConditionTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Copyright (C) 2022 synetics GmbH
+ * Copyright (C) 2016-2022 Benjamin Heisig
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Benjamin Heisig <https://benjamin.heisig.name/>
+ * @copyright Copyright (C) 2022 synetics GmbH
+ * @copyright Copyright (C) 2016-2022 Benjamin Heisig
+ * @license http://www.gnu.org/licenses/agpl-3.0 GNU Affero General Public License (AGPL)
+ * @link https://github.com/i-doit/api-client-php
+ */
+
+declare(strict_types=1);
+
+namespace Idoit\APIClient;
+
+use \Exception;
+use Idoit\APIClient\Constants\Category;
+
+class CMDBConditionTest extends BaseTest {
+
+    /**
+     * @throws Exception on error
+     */
+    public function testReadObjectByCondition() {
+        $objectID = $this->createServer();
+
+        $attributes = [
+            'inventory_no' => $this->generateRandomString(),
+            'order_no'     => $this->generateRandomString(),
+            'invoice_no'   => $this->generateRandomString()
+        ];
+
+        $entryID = $this->useCMDBCategory()->save(
+            $objectID,
+            Category::CATG__ACCOUNTING,
+            $attributes
+        );
+
+        $this->assertIsInt($entryID);
+        $this->isID($entryID);
+
+        $entries = $this->useCMDBCategory()->read(
+            $objectID,
+            Category::CATG__ACCOUNTING
+        );
+
+        $this->assertIsArray($entries);
+        $this->assertCount(1, $entries);
+        $this->assertArrayHasKey(0, $entries);
+
+        $entry = $entries[0];
+
+        // Check attributes:
+        foreach ($attributes as $attribute => $value) {
+            $this->assertArrayHasKey($attribute, $entry);
+            $this->assertIsString($entry[$attribute]);
+            $this->assertSame($value, $entry[$attribute]);
+        }
+
+        $cmdbCondition = $this->useCMDBCondition();
+        foreach ($attributes as $attribute => $value) {
+            $conditions = [['property'   => "C__CATG__ACCOUNTING-".$attribute,
+                            'comparison' => "=",
+                            'value'      => $value,
+                            ]];
+            $objects = $cmdbCondition->read($conditions);
+            $this->assertSame($objectID, intval($objects[0]['id']));         
+        }
+
+    }
+
+}

--- a/tests/Idoit/APIClient/CMDBConditionTest.php
+++ b/tests/Idoit/APIClient/CMDBConditionTest.php
@@ -79,9 +79,8 @@ class CMDBConditionTest extends BaseTest {
                             'value'      => $value,
                             ]];
             $objects = $cmdbCondition->read($conditions);
-            $this->assertSame($objectID, intval($objects[0]['id']));         
+            $this->assertSame($objectID, intval($objects[0]['id']));
         }
-
     }
 
 }


### PR DESCRIPTION
Add cmdb.condition.read method

### Added

File: src/CMDBCondition.php

Example:
   $condition = new CMDBCondition($api);
   $result = $condition->read(
   [
      [
         'property'   => "C__CATG__ACCOUNTING-order_no",
         'comparison' => "=",
         'value'      => "ORDER4711",
      ]
   ]);

### Confirmation

By sending this pull request I accept the following conditions:

-   [x] I have read the code of conduct and accept it.
-   [x] I have read the contributing guidelines and accept them.
-   [x] I accept that my contribution will be licensed under the AGPLv3.
