### PR TITLE
Fix incorrect category reference

### DIFF
--- a/tests/Idoit/APIClient/CMDBObjectTest.php
+++ b/tests/Idoit/APIClient/CMDBObjectTest.php
@@ -235,7 +235,7 @@ class CMDBObjectTest extends BaseTest {
         $objectID = $result['id'];
         $modelEntryID = (int) $result['categories'][Category::CATG__MODEL][0];
         $firstIPEntryID = $result['categories'][Category::CATG__IP][0];
-        $secondIPEntryID = $result['categories'][Category::CATG__IP][0];
+        $secondIPEntryID = $result['categories'][Category::CATG__IP][1];
 
         $model = $this->useCMDBCategory()->readOneByID($objectID, Category::CATG__MODEL, $modelEntryID);
         $this->assertArrayHasKey('id', $model);


### PR DESCRIPTION
Bugfix in unit test

### Fixed

- Incorrect reference in CMDBObjectTest->testCreateWithCategories() (https://github.com/i-doit/api-client-php/issues/27)

### Confirmation

By sending this pull request I accept the following conditions:

-   [x] I have read the code of conduct and accept it.
-   [x] I have read the contributing guidelines and accept them.
-   [x] I accept that my contribution will be licensed under the AGPLv3.
