### PR TITLE
.env variable prefixed with idoit to prevent collisions with os

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,20 +1,20 @@
 # URL to i-doit API (required):
-URL=https://demo.i-doit.com/src/jsonrpc.php
+IDOIT_URL=https://demo.i-doit.com/src/jsonrpc.php
 
 # PORT to i-doit API (optional):
-#PORT=8443
+#IDOIT_PORT=8443
 
 # API key to select tenant (required):
-KEY=xxx
+IDOIT_KEY=xxx
 
 # Login with user name (optional):
-#USERNAME=admin
+#IDOIT_USERNAME=admin
 
 # User's password (optional):
-#PASSWORD=admin
+#IDOIT_PASSWORD=admin
 
 # Enforce language (optional):
-#LANGUAGE=en
+#IDOIT_LANGUAGE=en
 
 # Disable security-related cURL options:
-#BYPASS_SECURE_CONNECTION=1
+#IDOIT_BYPASS_SECURE_CONNECTION=1

--- a/tests/Idoit/APIClient/APITest.php
+++ b/tests/Idoit/APIClient/APITest.php
@@ -230,7 +230,7 @@ class APITest extends BaseTest {
             'jsonrpc' => '2.0',
             'method' => 'idoit.version',
             'params' => [
-                'apikey' => getenv('KEY')
+                'apikey' => getenv('IDOIT_KEY')
             ],
             'id' => 1
         ];
@@ -252,7 +252,7 @@ class APITest extends BaseTest {
             'jsonrpc' => '2.0',
             'method' => 'idoit.version',
             'params' => [
-                'apikey' => getenv('KEY')
+                'apikey' => getenv('IDOIT_KEY')
             ],
             'id' => 1
         ];
@@ -460,7 +460,7 @@ class APITest extends BaseTest {
         $request = [
             'method' => 'idoit.version',
             'params' => [
-                'apikey' => getenv('KEY')
+                'apikey' => getenv('IDOIT_KEY')
             ],
             'id' => 1
         ];
@@ -502,7 +502,7 @@ class APITest extends BaseTest {
             'jsonrpc' => $versionNumber,
             'method' => 'idoit.version',
             'params' => [
-                'apikey' => getenv('KEY')
+                'apikey' => getenv('IDOIT_KEY')
             ],
             'id' => 1
         ];
@@ -541,7 +541,7 @@ class APITest extends BaseTest {
             'jsonrpc' => '2.0',
             'method' => 'idoit.version',
             'params' => [
-                'apikey' => getenv('KEY')
+                'apikey' => getenv('IDOIT_KEY')
             ],
             'id' => $identifier
         ];
@@ -579,7 +579,7 @@ class APITest extends BaseTest {
             'jsonrpc' => '2.0',
             'method' => 'idoit.version',
             'params' => [
-                'apikey' => getenv('KEY')
+                'apikey' => getenv('IDOIT_KEY')
             ],
             'id' => $identifier
         ];
@@ -600,7 +600,7 @@ class APITest extends BaseTest {
         $request = [
             'jsonrpc' => '2.0',
             'params' => [
-                'apikey' => getenv('KEY')
+                'apikey' => getenv('IDOIT_KEY')
             ],
             'id' => 1
         ];
@@ -643,7 +643,7 @@ class APITest extends BaseTest {
             'jsonrpc' => '2.0',
             'method' => $method,
             'params' => [
-                'apikey' => getenv('KEY')
+                'apikey' => getenv('IDOIT_KEY')
             ],
             'id' => 1
         ];
@@ -681,7 +681,7 @@ class APITest extends BaseTest {
             'jsonrpc' => '2.0',
             'method' => $method,
             'params' => [
-                'apikey' => getenv('KEY')
+                'apikey' => getenv('IDOIT_KEY')
             ],
             'id' => 1
         ];
@@ -705,7 +705,7 @@ class APITest extends BaseTest {
                 'jsonrpc' => '2.0',
                 'method' => 'idoit.version',
                 'params' => [
-                    'apikey' => getenv('KEY')
+                    'apikey' => getenv('IDOIT_KEY')
                 ],
                 'id' => 1
             ],
@@ -713,7 +713,7 @@ class APITest extends BaseTest {
                 'jsonrpc' => '2.0',
                 'method' => 'idoit.version',
                 'params' => [
-                    'apikey' => getenv('KEY')
+                    'apikey' => getenv('IDOIT_KEY')
                 ],
                 'id' => $this->generateRandomString()
             ],
@@ -721,7 +721,7 @@ class APITest extends BaseTest {
                 'jsonrpc' => '2.0',
                 'method' => 'idoit.version',
                 'params' => [
-                    'apikey' => getenv('KEY')
+                    'apikey' => getenv('IDOIT_KEY')
                 ],
                 'id' => 1
             ]
@@ -746,7 +746,7 @@ class APITest extends BaseTest {
                 'jsonrpc' => '2.0',
                 'method' => 'idoit.version',
                 'params' => [
-                    'apikey' => getenv('KEY')
+                    'apikey' => getenv('IDOIT_KEY')
                 ],
                 'id' => 1
             ],
@@ -789,7 +789,7 @@ class APITest extends BaseTest {
             'jsonrpc' => '2.0',
             'method' => 'idoit.version',
             'params' => [
-                'apikey' => getenv('KEY')
+                'apikey' => getenv('IDOIT_KEY')
             ]
         ];
 
@@ -812,21 +812,21 @@ class APITest extends BaseTest {
                 'jsonrpc' => '2.0',
                 'method' => 'idoit.version',
                 'params' => [
-                    'apikey' => getenv('KEY')
+                    'apikey' => getenv('IDOIT_KEY')
                 ]
             ],
             [
                 'jsonrpc' => '2.0',
                 'method' => 'cmdb.object.read',
                 'params' => [
-                    'apikey' => getenv('KEY')
+                    'apikey' => getenv('IDOIT_KEY')
                 ]
             ],
             [
                 'jsonrpc' => '2.0',
                 'method' => 'cmdb.category.read',
                 'params' => [
-                    'apikey' => getenv('KEY')
+                    'apikey' => getenv('IDOIT_KEY')
                 ]
             ]
         ];
@@ -847,7 +847,7 @@ class APITest extends BaseTest {
                 'jsonrpc' => '2.0',
                 'method' => 'idoit.version',
                 'params' => [
-                    'apikey' => getenv('KEY')
+                    'apikey' => getenv('IDOIT_KEY')
                 ],
                 'id' => 1
             ],
@@ -855,14 +855,14 @@ class APITest extends BaseTest {
                 'jsonrpc' => '2.0',
                 'method' => 'cmdb.object.read',
                 'params' => [
-                    'apikey' => getenv('KEY')
+                    'apikey' => getenv('IDOIT_KEY')
                 ]
             ],
             [
                 'jsonrpc' => '2.0',
                 'method' => 'cmdb.category.read',
                 'params' => [
-                    'apikey' => getenv('KEY')
+                    'apikey' => getenv('IDOIT_KEY')
                 ],
                 'id' => 2
             ]

--- a/tests/Idoit/APIClient/BaseTest.php
+++ b/tests/Idoit/APIClient/BaseTest.php
@@ -127,27 +127,27 @@ abstract class BaseTest extends TestCase {
      */
     public function setUp(): void {
         $config = [
-            API::URL => getenv('URL'),
-            API::KEY => getenv('KEY'),
-            API::BYPASS_SECURE_CONNECTION => getenv('BYPASS_SECURE_CONNECTION')
+            API::URL => getenv('IDOIT_URL'),
+            API::KEY => getenv('IDOIT_KEY'),
+            API::BYPASS_SECURE_CONNECTION => getenv('IDOIT_BYPASS_SECURE_CONNECTION')
         ];
 
-        if (getenv('PORT') !== false) {
-            $config[API::PORT] = (int) getenv('PORT');
+        if (getenv('IDOIT_PORT') !== false) {
+            $config[API::PORT] = (int) getenv('IDOIT_PORT');
         }
 
         if (getenv('IDOIT_LANGUAGE') !== false) {
             $config[API::LANGUAGE] = getenv('IDOIT_LANGUAGE');
         }
 
-        if (getenv('USERNAME') !== false && getenv('PASSWORD') !== false) {
-            $config[API::USERNAME] = getenv('USERNAME');
-            $config[API::PASSWORD] = getenv('PASSWORD');
+        if (getenv('IDOIT_USERNAME') !== false && getenv('IDOIT_PASSWORD') !== false) {
+            $config[API::USERNAME] = getenv('IDOIT_USERNAME');
+            $config[API::PASSWORD] = getenv('IDOIT_PASSWORD');
         }
 
-        if (getenv('BYPASS_SECURE_CONNECTION') !== false) {
+        if (getenv('IDOIT_BYPASS_SECURE_CONNECTION') !== false) {
             $config[API::BYPASS_SECURE_CONNECTION] = filter_var(
-                getenv('BYPASS_SECURE_CONNECTION'),
+                getenv('IDOIT_BYPASS_SECURE_CONNECTION'),
                 FILTER_VALIDATE_BOOLEAN,
                 FILTER_NULL_ON_FAILURE
             );

--- a/tests/Idoit/APIClient/CMDBCategoryInfoTest.php
+++ b/tests/Idoit/APIClient/CMDBCategoryInfoTest.php
@@ -158,7 +158,7 @@ class CMDBCategoryInfoTest extends BaseTest {
             'method' => 'cmdb.category_info',
             'params' => array(
                 'category' => $categoryConstant,
-                'apikey' => getenv('KEY')
+                'apikey' => getenv('IDOIT_KEY')
             ),
             'id' => 1
         ];
@@ -187,7 +187,7 @@ class CMDBCategoryInfoTest extends BaseTest {
             'params' => array(
                 'category' => $categoryConstant,
                 'objID' => $objectID,
-                'apikey' => getenv('KEY')
+                'apikey' => getenv('IDOIT_KEY')
             ),
             'id' => 1
         ];

--- a/tests/Idoit/APIClient/Extension/PrintMetaData.php
+++ b/tests/Idoit/APIClient/Extension/PrintMetaData.php
@@ -109,27 +109,27 @@ final class PrintMetaData implements BeforeFirstTestHook {
     protected function connectToAPI(): self {
         try {
             $config = [
-                API::URL => getenv('URL'),
-                API::KEY => getenv('KEY'),
-                API::BYPASS_SECURE_CONNECTION => getenv('BYPASS_SECURE_CONNECTION')
+                API::URL => getenv('IDOIT_URL'),
+                API::KEY => getenv('IDOIT_KEY'),
+                API::BYPASS_SECURE_CONNECTION => getenv('IDOIT_BYPASS_SECURE_CONNECTION')
             ];
 
-            if (getenv('PORT') !== false) {
-                $config[API::PORT] = (int) getenv('PORT');
+            if (getenv('IDOIT_PORT') !== false) {
+                $config[API::PORT] = (int) getenv('IDOIT_PORT');
             }
 
             if (getenv('IDOIT_LANGUAGE') !== false) {
                 $config[API::LANGUAGE] = getenv('IDOIT_LANGUAGE');
             }
 
-            if (getenv('USERNAME') !== false && getenv('PASSWORD') !== false) {
-                $config[API::USERNAME] = getenv('USERNAME');
-                $config[API::PASSWORD] = getenv('PASSWORD');
+            if (getenv('IDOIT_USERNAME') !== false && getenv('IDOIT_PASSWORD') !== false) {
+                $config[API::USERNAME] = getenv('IDOIT_USERNAME');
+                $config[API::PASSWORD] = getenv('IDOIT_PASSWORD');
             }
 
-            if (getenv('BYPASS_SECURE_CONNECTION') !== false) {
+            if (getenv('IDOIT_BYPASS_SECURE_CONNECTION') !== false) {
                 $config[API::BYPASS_SECURE_CONNECTION] = filter_var(
-                    getenv('BYPASS_SECURE_CONNECTION'),
+                    getenv('IDOIT_BYPASS_SECURE_CONNECTION'),
                     FILTER_VALIDATE_BOOLEAN,
                     FILTER_NULL_ON_FAILURE
                 );
@@ -180,7 +180,7 @@ final class PrintMetaData implements BeforeFirstTestHook {
      * @return self Returns itself
      */
     protected function printMetaData(): self {
-        $url = getenv('URL');
+        $url = getenv('IDOIT_URL');
         $libName = $this->composer['name'];
         $libVersion = $this->composer['extra']['version'];
         $phpVersion = PHP_VERSION;

--- a/tests/Idoit/APIClient/Issues/API134Test.php
+++ b/tests/Idoit/APIClient/Issues/API134Test.php
@@ -74,7 +74,7 @@ class API134Test extends BaseTest {
             'jsonrpc' => '2.0',
             'method' => $method,
             'params' => [
-                'apikey' => getenv('KEY'),
+                'apikey' => getenv('IDOIT_KEY'),
                 'objID' => $objectID,
                 'category' => Category::CATG__MODEL,
                 'data' => [

--- a/tests/Idoit/APIClient/Issues/API153Test.php
+++ b/tests/Idoit/APIClient/Issues/API153Test.php
@@ -105,31 +105,31 @@ class API153Test extends BaseTest {
      */
     public function testFaultyCredentials(string $username, string $password) {
         if (empty($username)) {
-            $username = getenv('USERNAME');
+            $username = getenv('IDOIT_USERNAME');
         }
 
         if (empty($password)) {
-            $password = getenv('PASSWORD');
+            $password = getenv('IDOIT_PASSWORD');
         }
 
         $config = [
             API::USERNAME => $username,
             API::PASSWORD => $password,
-            API::KEY => getenv('KEY'),
-            API::URL => getenv('URL')
+            API::KEY => getenv('IDOIT_KEY'),
+            API::URL => getenv('IDOIT_URL')
         ];
 
         if (getenv('IDOIT_LANGUAGE') !== false) {
             $config[API::LANGUAGE] = getenv('IDOIT_LANGUAGE');
         }
 
-        if (getenv('PORT') !== false) {
-            $config[API::PORT] = (int) getenv('PORT');
+        if (getenv('IDOIT_PORT') !== false) {
+            $config[API::PORT] = (int) getenv('IDOIT_PORT');
         }
 
-        if (getenv('BYPASS_SECURE_CONNECTION') !== false) {
+        if (getenv('IDOIT_BYPASS_SECURE_CONNECTION') !== false) {
             $config[API::BYPASS_SECURE_CONNECTION] = filter_var(
-                getenv('BYPASS_SECURE_CONNECTION'),
+                getenv('IDOIT_BYPASS_SECURE_CONNECTION'),
                 FILTER_VALIDATE_BOOLEAN,
                 FILTER_NULL_ON_FAILURE
             );
@@ -141,7 +141,7 @@ class API153Test extends BaseTest {
             'jsonrpc' => '2.0',
             'method' => 'idoit.version',
             'params' => [
-                'apikey' => getenv('KEY')
+                'apikey' => getenv('IDOIT_KEY')
             ],
             'id' => 1
         ];
@@ -162,22 +162,22 @@ class API153Test extends BaseTest {
     public function testFaultyKey(string $apiKey) {
         $config = [
             API::KEY => $apiKey,
-            API::USERNAME => getenv('USERNAME'),
-            API::PASSWORD => getenv('PASSWORD'),
-            API::URL => getenv('URL')
+            API::USERNAME => getenv('IDOIT_USERNAME'),
+            API::PASSWORD => getenv('IDOIT_PASSWORD'),
+            API::URL => getenv('IDOIT_URL')
         ];
 
         if (getenv('IDOIT_LANGUAGE') !== false) {
             $config[API::LANGUAGE] = getenv('IDOIT_LANGUAGE');
         }
 
-        if (getenv('PORT') !== false) {
-            $config[API::PORT] = (int) getenv('PORT');
+        if (getenv('IDOIT_PORT') !== false) {
+            $config[API::PORT] = (int) getenv('IDOIT_PORT');
         }
 
-        if (getenv('BYPASS_SECURE_CONNECTION') !== false) {
+        if (getenv('IDOIT_BYPASS_SECURE_CONNECTION') !== false) {
             $config[API::BYPASS_SECURE_CONNECTION] = filter_var(
-                getenv('BYPASS_SECURE_CONNECTION'),
+                getenv('IDOIT_BYPASS_SECURE_CONNECTION'),
                 FILTER_VALIDATE_BOOLEAN,
                 FILTER_NULL_ON_FAILURE
             );

--- a/tests/Idoit/APIClient/Issues/API166Test.php
+++ b/tests/Idoit/APIClient/Issues/API166Test.php
@@ -62,7 +62,7 @@ class API166Test extends BaseTest {
                 'object' => $objectID,
                 'category' => Category::CATG__ACCOUNTING,
                 'entry' => $entryID,
-                'apikey' => getenv('KEY')
+                'apikey' => getenv('IDOIT_KEY')
             ],
             'id' => 1
         ];
@@ -104,7 +104,7 @@ class API166Test extends BaseTest {
                 'object' => $objectID,
                 'category' => Category::CATG__ACCOUNTING,
                 'entry' => $entryID,
-                'apikey' => getenv('KEY')
+                'apikey' => getenv('IDOIT_KEY')
             ],
             'id' => 1
         ];
@@ -146,7 +146,7 @@ class API166Test extends BaseTest {
                 'object' => $objectID,
                 'category' => Category::CATG__ACCOUNTING,
                 'entry' => $entryID,
-                'apikey' => getenv('KEY')
+                'apikey' => getenv('IDOIT_KEY')
             ],
             'id' => 1
         ];
@@ -188,7 +188,7 @@ class API166Test extends BaseTest {
                 'objID' => $objectID,
                 'category' => Category::CATG__ACCOUNTING,
                 'cateID' => $entryID,
-                'apikey' => getenv('KEY')
+                'apikey' => getenv('IDOIT_KEY')
             ],
             'id' => 1
         ];
@@ -230,7 +230,7 @@ class API166Test extends BaseTest {
                 'object' => $objectID,
                 'category' => Category::CATG__NETWORK_PORT,
                 'entry' => $entryID,
-                'apikey' => getenv('KEY')
+                'apikey' => getenv('IDOIT_KEY')
             ],
             'id' => 1
         ];
@@ -273,7 +273,7 @@ class API166Test extends BaseTest {
                 'object' => $objectID,
                 'category' => Category::CATG__NETWORK_PORT,
                 'entry' => $entryID,
-                'apikey' => getenv('KEY')
+                'apikey' => getenv('IDOIT_KEY')
             ],
             'id' => 1
         ];
@@ -316,7 +316,7 @@ class API166Test extends BaseTest {
                 'object' => $objectID,
                 'category' => Category::CATG__NETWORK_PORT,
                 'entry' => $entryID,
-                'apikey' => getenv('KEY')
+                'apikey' => getenv('IDOIT_KEY')
             ],
             'id' => 1
         ];
@@ -359,7 +359,7 @@ class API166Test extends BaseTest {
                 'objID' => $objectID,
                 'category' => Category::CATG__NETWORK_PORT,
                 'cateID' => $entryID,
-                'apikey' => getenv('KEY')
+                'apikey' => getenv('IDOIT_KEY')
             ],
             'id' => 1
         ];

--- a/tests/Idoit/APIClient/Issues/API205Test.php
+++ b/tests/Idoit/APIClient/Issues/API205Test.php
@@ -231,7 +231,7 @@ class API205Test extends BaseTest {
 //            'jsonrpc' => '2.0',
 //            'method' => 'cmdb.category.save',
 //            'params' => [
-//                'apikey' => getenv('KEY'),
+//                'apikey' => getenv('IDOIT_KEY'),
 //                'object' => $objectID,
 //                'category' => $categoryConstant,
 //                'data' => [
@@ -282,7 +282,7 @@ class API205Test extends BaseTest {
             'jsonrpc' => '2.0',
             'method' => 'cmdb.category.save',
             'params' => [
-                'apikey' => getenv('KEY'),
+                'apikey' => getenv('IDOIT_KEY'),
                 'object' => $objectID,
                 'category' => 'C__CATG__CUSTOM_FIELDS_API_205_VIRTUAL_PROPERTIES',
                 'data' => [


### PR DESCRIPTION
<!--
Thanks for your pull request! Please take a few minutes to fill out the following sections.
-->

Short description
.env variable prefixed with idoit to prevent collisions with os
Long description
.env variable prefixed with idoit to prevent collisions with os

### Changed

-   Naming of .env variables - prefix "IDOIT" added
-   Access of .env variables changed to use correct .env variable names

### Confirmation

By sending this pull request I accept the following conditions:

-   [x] I have read the code of conduct and accept it.
-   [x] I have read the contributing guidelines and accept them.
-   [x] I accept that my contribution will be licensed under the AGPLv3.
