### PR TITLE
Release 1.0.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,9 +20,9 @@ jobs:
           - '8.2'
           - '8.3'
         experimental: [false]
-        include:
-          - php-versions: nightly
-            experimental: true
+        #include:
+        #  - php-versions: nightly
+        #    experimental: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
+## [1.0.1][] – 2024-12-17
+
+**Note:** For the next minor version (1.1.0) we plan to drop support for PHP `8.0`.
+
+### Fixed
+
+-   `Request::requireSuccessFor()`: Fix misleading error response for (successfully) saving category data
+
+### Changed
+
+-   Slightly updating the README to represent the current state of the client (PHP and i-doit compatibility)
+
 ## [1.0.0][] – 2024-12-16
 
 **Note:** Support for all PHP `7` versions has been dropped. PHP `8+` only, from now on :)
@@ -233,7 +245,8 @@ Happy summer time ⛱️
 
 Initial release
 
-[Unreleased]: https://github.com/i-doit/api-client-php/compare/1.0.0...HEAD
+[Unreleased]: https://github.com/i-doit/api-client-php/compare/1.0.1...HEAD
+[1.0.1]: https://github.com/i-doit/api-client-php/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/i-doit/api-client-php/compare/0.10...1.0.0
 [0.10]: https://github.com/i-doit/api-client-php/compare/0.9...0.10
 [0.9]: https://github.com/i-doit/api-client-php/compare/0.8...0.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--   `Request::requireSuccessFor()`: Fix misleading error response for (successfully) saving category data
+-   `Request::requireSuccessFor()`: Fix misleading error response for (successfully) saving category data when using `CMDBCategory`
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Easy-to-use, but feature-rich client library for i-doit's JSON-RPC API
 
 [![Latest stable version](https://img.shields.io/packagist/v/idoit/apiclient.svg)](https://packagist.org/packages/idoit/apiclient)
-[![Minimum PHP version](https://img.shields.io/badge/php-%3E%3D%207.4-8892BF.svg)](https://php.net/)
+[![Minimum PHP version](https://img.shields.io/badge/php-%3E%3D%208.0-8892BF.svg)](https://php.net/)
 [![Build status](https://github.com/i-doit/api-client-php/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/i-doit/api-client-php/actions)
 
 **Please note: This project is not an official product by synetics GmbH. synetics GmbH doesn't provide any commercial support.**
@@ -39,9 +39,9 @@ What's new? Take a look at the [changelog](CHANGELOG.md).
 
 Meet these simple requirements before using the client:
 
--   A running instance of i-doit pro/open, version `1.18.1` or higher (older versions may work but are not supported)
--   i-doit API add-on, version `1.12.3` or higher (older versions may work but are not supported)
--   PHP, version `8.0` or higher (`8.1` is recommended, `7.4` should work but is deprecated)
+-   A running instance of i-doit pro/open, version `30` or higher (older versions may work but are not supported)
+-   i-doit API add-on, version `2.0` or higher (older versions may work but are not supported)
+-   PHP, version `8.0` or higher (`8.2` is recommended)
 -   PHP modules `curl`, `date`, `json`, `openssl` and `zlib`
 
 As a rule of thumb, always use the latest stable releases to benefit from new features, improvements and bug fixes.

--- a/src/CMDBCategory.php
+++ b/src/CMDBCategory.php
@@ -401,7 +401,7 @@ class CMDBCategory extends Request {
                 }
             }
 
-            $entryIDs[] = (int) $entry['id'];
+            $entryIDs[] = (int) ($entry['id'] ?? $entry['entry']);
         }
 
         return $entryIDs;

--- a/src/Request.php
+++ b/src/Request.php
@@ -62,7 +62,7 @@ abstract class Request implements Calls {
      */
     protected function requireSuccessFor(array $result): int {
         $idExists = array_key_exists('id', $result) || array_key_exists('entry', $result);
-        $idIsNumeric = is_numeric($result['id'] ?? 0) || is_numeric($result['entry'] ?? 0);
+        $idIsNumeric = is_numeric($result['id'] ?? $result['entry'] ?? null);
         $isSuccess = array_key_exists('success', $result) && $result['success'] === true;
 
         if (!$idExists || !$idIsNumeric || !$isSuccess) {

--- a/src/Request.php
+++ b/src/Request.php
@@ -61,11 +61,11 @@ abstract class Request implements Calls {
      * @throws RuntimeException on error
      */
     protected function requireSuccessFor(array $result): int {
-        if ((!array_key_exists('id', $result) && !array_key_exists('entry', $result)) ||
-            (!is_numeric($result['id'] ?? 0) && !is_numeric($result['entry'] ?? 0)) ||
-            !array_key_exists('success', $result) ||
-            $result['success'] !== true) {
+        $idExists = array_key_exists('id', $result) || array_key_exists('entry', $result);
+        $idIsNumeric = is_numeric($result['id'] ?? 0) || is_numeric($result['entry'] ?? 0);
+        $isSuccess = array_key_exists('success', $result) && $result['success'] === true;
 
+        if (!$idExists || !$idIsNumeric || !$isSuccess) {
             if (array_key_exists('message', $result)) {
                 throw new RuntimeException(sprintf('Bad result: %s', $result['message']));
             } else {

--- a/src/Request.php
+++ b/src/Request.php
@@ -61,10 +61,11 @@ abstract class Request implements Calls {
      * @throws RuntimeException on error
      */
     protected function requireSuccessFor(array $result): int {
-        if (!array_key_exists('id', $result) ||
-            !is_numeric($result['id']) ||
+        if ((!array_key_exists('id', $result) && !array_key_exists('entry', $result)) ||
+            (!is_numeric($result['id'] ?? 0) && !is_numeric($result['entry'] ?? 0)) ||
             !array_key_exists('success', $result) ||
             $result['success'] !== true) {
+
             if (array_key_exists('message', $result)) {
                 throw new RuntimeException(sprintf('Bad result: %s', $result['message']));
             } else {
@@ -72,7 +73,7 @@ abstract class Request implements Calls {
             }
         }
 
-        return (int) $result['id'];
+        return (int) ($result['id'] ?? $result['entry']);
     }
 
     /**


### PR DESCRIPTION
**Note:** For the next minor version (1.1.0) we plan to drop support for PHP `8.0`.

### Fixed

-   `Request::requireSuccessFor()`: Fix misleading error response for (successfully) saving category data when using `CMDBCategory`

### Changed

-   Slightly updating the README to represent the current state of the client (PHP and i-doit compatibility)